### PR TITLE
Add Distributed Tracing with OpenTelemetry and Jaeger

### DIFF
--- a/src/ApiGateways/YarpApiGateway/Program.cs
+++ b/src/ApiGateways/YarpApiGateway/Program.cs
@@ -1,9 +1,12 @@
 using Microsoft.AspNetCore.RateLimiting;
+using BuildingBlocks.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddReverseProxy()
     .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
+
+builder.Services.AddAppObservability(builder.Configuration);
 
 builder.Services.AddRateLimiter(rateLimiterOptions =>
 {

--- a/src/ApiGateways/YarpApiGateway/YarpApiGateway.csproj
+++ b/src/ApiGateways/YarpApiGateway/YarpApiGateway.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="Yarp.ReverseProxy" Version="2.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\BuildingBlocks\BuildingBlocks\BuildingBlocks.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/BuildingBlocks/BuildingBlocks/BuildingBlocks.csproj
+++ b/src/BuildingBlocks/BuildingBlocks/BuildingBlocks.csproj
@@ -13,6 +13,16 @@
     <PackageReference Include="Mapster" Version="7.4.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.6.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.12.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.MassTransit" Version="1.0.0-beta.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.12.0-beta.2" />
   </ItemGroup>
 
 </Project>

--- a/src/BuildingBlocks/BuildingBlocks/Observability/ObservabilityExtensions.cs
+++ b/src/BuildingBlocks/BuildingBlocks/Observability/ObservabilityExtensions.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace BuildingBlocks.Observability;
+public static class ObservabilityExtensions
+{
+    public static IServiceCollection AddAppObservability(this IServiceCollection services, IConfiguration configuration)
+    {
+        var serviceName = configuration["OTEL_SERVICE_NAME"]
+                  ?? configuration["ServiceName"]
+                  ?? AppDomain.CurrentDomain.FriendlyName;
+
+        services.AddOpenTelemetry()
+            .ConfigureResource(r => r.AddService(serviceName))
+            .WithTracing(tracing => tracing
+                .AddAspNetCoreInstrumentation()
+                .AddHttpClientInstrumentation()
+                .AddGrpcClientInstrumentation()
+                .AddSqlClientInstrumentation()
+                .AddMassTransitInstrumentation()
+                .AddSource(serviceName)
+                .AddOtlpExporter()
+            );
+
+        return services;
+    }
+}

--- a/src/Services/Basket/Basket.API/Program.cs
+++ b/src/Services/Basket/Basket.API/Program.cs
@@ -1,4 +1,5 @@
 using BuildingBlocks.Messaging.MassTransit;
+using BuildingBlocks.Observability;
 using Discount.Grpc;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -14,6 +15,8 @@ builder.Services.AddMediatR(config =>
     config.AddOpenBehavior(typeof(ValidationBehavior<,>));
     config.AddOpenBehavior(typeof(LoggingBehavior<,>));
 });
+
+builder.Services.AddAppObservability(builder.Configuration);
 
 // Data services
 builder.Services.AddMarten(opts =>

--- a/src/Services/Catalog/Catalog.API/Program.cs
+++ b/src/Services/Catalog/Catalog.API/Program.cs
@@ -1,3 +1,4 @@
+using BuildingBlocks.Observability;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 
@@ -11,6 +12,8 @@ builder.Services.AddMediatR(config =>
     config.AddOpenBehavior(typeof(ValidationBehavior<,>));
     config.AddOpenBehavior(typeof(LoggingBehavior<,>));
 });
+
+builder.Services.AddAppObservability(builder.Configuration);
 
 builder.Services.AddMarten(opts =>
 {

--- a/src/Services/Discount/Discount.Grpc/Discount.Grpc.csproj
+++ b/src/Services/Discount/Discount.Grpc/Discount.Grpc.csproj
@@ -30,6 +30,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\BuildingBlocks\BuildingBlocks\BuildingBlocks.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Protobuf Include="Protos\discount.proto" GrpcServices="Server" />
   </ItemGroup>
 

--- a/src/Services/Discount/Discount.Grpc/Program.cs
+++ b/src/Services/Discount/Discount.Grpc/Program.cs
@@ -1,6 +1,7 @@
 using Discount.Grpc.Data;
 using Discount.Grpc.Services;
 using Microsoft.EntityFrameworkCore;
+using BuildingBlocks.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -8,6 +9,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddGrpc();
 builder.Services.AddDbContext<DiscountContext>(opts =>
         opts.UseSqlite(builder.Configuration.GetConnectionString("Database")));
+
+builder.Services.AddAppObservability(builder.Configuration);
 
 var app = builder.Build();
 

--- a/src/Services/Ordering/Ordering.Infrastructure/DependencyInjection.cs
+++ b/src/Services/Ordering/Ordering.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Diagnostics;
+﻿using BuildingBlocks.Observability;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Ordering.Application.Data;
@@ -23,6 +24,8 @@ public static class DependencyInjection
         });
 
         services.AddScoped<IApplicationDbContext, ApplicationDbContext>();
+
+        services.AddAppObservability(configuration);
 
         return services;
     }

--- a/src/WebApps/Shopping.Web/Program.cs
+++ b/src/WebApps/Shopping.Web/Program.cs
@@ -1,3 +1,5 @@
+using BuildingBlocks.Observability;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -20,6 +22,7 @@ builder.Services.AddRefitClient<IOrderingService>()
         c.BaseAddress = new Uri(builder.Configuration["ApiSettings:GatewayAddress"]!);
     });
 
+builder.Services.AddAppObservability(builder.Configuration);
 
 var app = builder.Build();
 

--- a/src/WebApps/Shopping.Web/Shopping.Web.csproj
+++ b/src/WebApps/Shopping.Web/Shopping.Web.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="Refit.HttpClientFactory" Version="8.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\BuildingBlocks\BuildingBlocks\BuildingBlocks.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -51,12 +51,22 @@ services:
       - "5672:5672"
       - "15672:15672"
 
+  eshop-jaeger:
+    container_name: eshop-jaeger
+    restart: always
+    ports: 
+        - "4317:4317"
+        - "4318:4318"
+        - "16686:16686"
+
   catalog.api:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_HTTP_PORTS=8080
       - ASPNETCORE_HTTPS_PORTS=8081
       - ConnectionStrings__Database=Server=catalogdb;Port=5432;Database=CatalogDb;User Id=postgres;Password=postgres;Include Error Detail=true
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://eshop-jaeger:4317
+      - OTEL_SERVICE_NAME=catalog-api
     depends_on:
       - catalogdb
     ports:
@@ -77,6 +87,8 @@ services:
       - MessageBroker__Host=amqp://ecommerce-mq:5672
       - MessageBroker__UserName=guest
       - MessageBroker__Password=guest
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://eshop-jaeger:4317
+      - OTEL_SERVICE_NAME=basket-api
     depends_on:
       - basketdb
       - distributedcache
@@ -95,6 +107,8 @@ services:
       - ASPNETCORE_HTTP_PORTS=8080
       - ASPNETCORE_HTTPS_PORTS=8081
       - ConnectionStrings__Database=Data Source=discountdb
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://eshop-jaeger:4317
+      - OTEL_SERVICE_NAME=discount-grpc
     ports:
       - "6002:8080"
       - "6062:8081"
@@ -112,6 +126,8 @@ services:
       - MessageBroker__UserName=guest
       - MessageBroker__Password=guest
       - FeatureManagement__OrderFullfilment=false 
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://eshop-jaeger:4317
+      - OTEL_SERVICE_NAME=ordering-api
     depends_on:
       - orderdb
       - messagebroker
@@ -127,6 +143,8 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_HTTP_PORTS=8080
       - ASPNETCORE_HTTPS_PORTS=8081
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://eshop-jaeger:4317
+      - OTEL_SERVICE_NAME=yarpapigateway
     depends_on:
       - catalog.api
       - basket.api
@@ -144,6 +162,8 @@ services:
       - ASPNETCORE_HTTP_PORTS=8080
       - ASPNETCORE_HTTPS_PORTS=8081
       - ApiSettings__GatewayAddress=http://yarpapigateway:8080
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://eshop-jaeger:4317
+      - OTEL_SERVICE_NAME=shopping-web
     depends_on:
       - yarpapigateway
     ports:

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -16,6 +16,9 @@ services:
   messagebroker:
     image: rabbitmq:management
 
+  eshop-jaeger:
+    image: jaegertracing/all-in-one:latest
+
   catalog.api:
     image: ${DOCKER_REGISTRY-}catalogapi
     build:


### PR DESCRIPTION
- Integrated OpenTelemetry tracing into all microservices.
- Added instrumentation for:
  - ASP.NET Core requests
  - HTTP Client calls
  - gRPC communication
  - SQL Client queries
  - MassTransit (RabbitMQ)
- Configured OTLP exporter to send traces to Jaeger.
- Updated docker-compose to include Jaeger service.
- Verified distributed traces across API Gateway, microservices, and Web UI.